### PR TITLE
feat : manage 각 페이지 unit 컴포넌트 UI 구조 구현.

### DIFF
--- a/components/common/Layout/NavigationTab/index.tsx
+++ b/components/common/Layout/NavigationTab/index.tsx
@@ -27,9 +27,9 @@ function Navigation() {
       </Tabs>
       <Tabs>
         <h2>
-          <Link href="/setting/service">Setting</Link>
+          <Link href="/setting">Setting</Link>
         </h2>
-        <Tab text={"서비스 안내"} path="/setting" />
+        <Tab text={"설정"} path="/setting" />
       </Tabs>
       {/* <div className="menu-icon">
         <i></i>

--- a/components/common/Page/Page.ts
+++ b/components/common/Page/Page.ts
@@ -1,0 +1,20 @@
+import styled from "styled-components";
+
+export const PageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px ;
+  margin-bottom: 60px;
+`
+
+export const PageDesc = styled.h2`
+  font-weight: normal;
+`
+
+export const PageContentsBox = styled.div`
+  background: #333333;
+  border-radius: 10px;
+  padding: 30px;
+  display: flex;
+  gap: 20px;
+`

--- a/components/common/Page/PageTitle.tsx
+++ b/components/common/Page/PageTitle.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { HiLocationMarker } from "react-icons/hi";
+import styled from "styled-components";
+
+type Props = {
+    title: string;
+    location: string;
+}
+
+export const TitleContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 40px;
+`
+
+export const Title = styled.h1`
+    font-size: 72px;
+`
+
+export const Location = styled.p`
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    font-size: 15px;
+`
+
+const PageTitle = (props: Props) => {
+    return (<TitleContainer>
+        <Title>{props.title}</Title>
+        <Location><HiLocationMarker /> {props.location}</Location>
+    </TitleContainer>
+    )
+}
+
+export default PageTitle

--- a/components/unit/ManageBudget/ManageBudget_container.tsx
+++ b/components/unit/ManageBudget/ManageBudget_container.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import ManageBudget_presenter from './ManageBudget_presenter'
+
+type Props = {}
+
+const ManageBudget_container = (props: Props) => {
+    // 여기에 로직을 담아 아래에 전달합니다.
+    return (
+        <ManageBudget_presenter />
+    )
+}
+
+export default ManageBudget_container

--- a/components/unit/ManageBudget/ManageBudget_presenter.tsx
+++ b/components/unit/ManageBudget/ManageBudget_presenter.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import PageTitle from '@/components/common/Page/PageTitle';
+import { PageContainer, PageContentsBox, PageDesc } from '@/components/common/Page/Page';
+
+type Props = {}
+
+const ManageBudget_presenter = (props: Props) => {
+    // 이 아래 UI를 구현합니다.
+    return (<PageContainer>
+        <PageTitle title='Manage' location='청주시 흥덕구 복대동' />
+        <PageDesc>예산 설정</PageDesc>
+        <PageContentsBox>
+            예산 설정 내용
+        </PageContentsBox>
+    </PageContainer>)
+}
+
+export default ManageBudget_presenter

--- a/components/unit/ManageCalendar/ManageCalendar_container.tsx
+++ b/components/unit/ManageCalendar/ManageCalendar_container.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import ManageCalendar_presenter from './ManageCalendar_presenter'
+
+type Props = {}
+
+const ManageCalendar_container = (props: Props) => {
+    // 여기에 로직을 담아 아래에 전달합니다.
+    return (
+        <ManageCalendar_presenter />
+    )
+}
+
+export default ManageCalendar_container

--- a/components/unit/ManageCalendar/ManageCalendar_presenter.tsx
+++ b/components/unit/ManageCalendar/ManageCalendar_presenter.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import PageTitle from '@/components/common/Page/PageTitle';
+import { PageContainer, PageContentsBox, PageDesc } from '@/components/common/Page/Page';
+
+type Props = {}
+
+const ManageCalendar_presenter = (props: Props) => {
+    // 이 아래 UI를 구현합니다.
+    return (<PageContainer>
+        <PageTitle title='Manage' location='청주시 흥덕구 복대동' />
+        <PageDesc>달력</PageDesc>
+        <PageContentsBox>
+            달력
+        </PageContentsBox>
+    </PageContainer>)
+}
+
+export default ManageCalendar_presenter

--- a/components/unit/ManageList/ManageList_container.tsx
+++ b/components/unit/ManageList/ManageList_container.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import ManageList_presenter from './ManageList_presenter'
+
+type Props = {}
+
+const ManageList_container = (props: Props) => {
+    // 여기에 로직을 담아 아래에 전달합니다.
+    return (
+        <ManageList_presenter />
+    )
+}
+
+export default ManageList_container

--- a/components/unit/ManageList/ManageList_presenter.tsx
+++ b/components/unit/ManageList/ManageList_presenter.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import * as S from './ManageList_styles'
+import { MdAccountBalanceWallet } from "react-icons/md";
+import { RiTodoFill } from "react-icons/ri";
+import PageTitle from '@/components/common/Page/PageTitle';
+import { PageContainer, PageContentsBox, PageDesc } from '@/components/common/Page/Page';
+
+type Props = {}
+
+const ManageList_presenter = (props: Props) => {
+    // 이 아래 UI를 구현합니다.
+    return (<PageContainer>
+        <PageTitle title='Manage' location='청주시 흥덕구 복대동' />
+        <PageDesc>월별내역</PageDesc>
+        <PageContentsBox>
+            <S.AccountSection>
+                <S.ListLabel>
+                    <MdAccountBalanceWallet /> 가계부
+                </S.ListLabel>
+                <S.ListBox>
+                    <S.List>
+                        <p>제목</p>
+                        <p>시간</p>
+                    </S.List>
+                    <S.List>
+                        <p>제목</p>
+                        <p>시간</p>
+                    </S.List>
+                </S.ListBox>
+            </S.AccountSection>
+            <S.TodoSection>
+                <S.ListLabel>
+                    <RiTodoFill />TO-DO
+                </S.ListLabel>
+                <S.ListBox>
+                    <S.List>
+                        <p>제목</p>
+                        <p>시간</p>
+                    </S.List>
+                    <S.List>
+                        <p>제목</p>
+                        <p>시간</p>
+                    </S.List>
+                    <S.List>
+                        <p>제목</p>
+                        <p>시간</p>
+                    </S.List>
+                    <S.List>
+                        <p>제목</p>
+                        <p>시간</p>
+                    </S.List>
+                </S.ListBox>
+            </S.TodoSection>
+        </PageContentsBox>
+    </PageContainer>)
+}
+
+export default ManageList_presenter

--- a/components/unit/ManageList/ManageList_styles.ts
+++ b/components/unit/ManageList/ManageList_styles.ts
@@ -1,0 +1,46 @@
+import styled from "styled-components";
+
+export const AccountSection = styled.section`
+    width: 100%;
+    display: flex;
+    gap: 10px;
+    flex-direction: column;
+    flex: 2;
+`
+
+export const TodoSection = styled.section`
+    width: 100%;
+    display: flex;
+    gap: 10px;
+    flex-direction: column;
+    flex: 1;
+`
+
+export const ListLabel = styled.label`
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    margin-bottom: 10px;
+`
+
+export const ListBox = styled.div`
+    display: flex;
+    gap: 10px;
+    flex-direction: column;
+`
+
+
+export const List = styled.div`
+    cursor: pointer;
+    width: 100%;
+    height: 60px;
+    display: flex;
+    align-items: center;
+    background-color: #4D4D4D;
+    border-radius: 10px;
+    padding: 0px 20px;
+    justify-content: space-between;
+    p{
+        font-size: 13px;
+    }
+`

--- a/components/unit/ManageListCreate/ManageListCreate_container.tsx
+++ b/components/unit/ManageListCreate/ManageListCreate_container.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import ManageListCreate_presenter from './ManageListCreate_presenter'
+
+type Props = {}
+
+const ManageListCreate_container = (props: Props) => {
+    // 여기에 로직을 담아 아래에 전달합니다.
+    return (
+        <ManageListCreate_presenter />
+    )
+}
+
+export default ManageListCreate_container

--- a/components/unit/ManageListCreate/ManageListCreate_presenter.tsx
+++ b/components/unit/ManageListCreate/ManageListCreate_presenter.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+type Props = {}
+
+const ManageListCreate_presenter = (props: Props) => {
+    // 이 아래 UI를 구현합니다.
+    return (
+        <div>ManageListCreate_presenter</div>
+    )
+}
+
+export default ManageListCreate_presenter

--- a/pages/manage/budget/index.tsx
+++ b/pages/manage/budget/index.tsx
@@ -1,10 +1,11 @@
+import ManageBudget_container from '@/components/unit/ManageBudget/ManageBudget_container'
 import React from 'react'
 
 type Props = {}
 
 const index = (props: Props) => {
     return (
-        <div>budget</div>
+        <ManageBudget_container />
     )
 }
 

--- a/pages/manage/calendar/index.tsx
+++ b/pages/manage/calendar/index.tsx
@@ -1,10 +1,11 @@
+import ManageCalendar_container from '@/components/unit/ManageCalendar/ManageCalendar_container'
 import React from 'react'
 
 type Props = {}
 
 const index = (props: Props) => {
     return (
-        <div>calendar</div>
+        <ManageCalendar_container />
     )
 }
 

--- a/pages/manage/list/index.tsx
+++ b/pages/manage/list/index.tsx
@@ -1,10 +1,11 @@
+import ManageList_container from '@/components/unit/ManageList/ManageList_container'
 import React from 'react'
 
 type Props = {}
 
 const index = (props: Props) => {
     return (
-        <div>list</div>
+        <ManageList_container />
     )
 }
 


### PR DESCRIPTION
style : 각페이지에 들어가는 title 컴포넌트 및 기본 스타일 분리구현.
fix : 네비게이션 탭의 "서비스"->"설정" 으로 임시 변경.

![Screenshot 2023-03-20 at 21 07 20](https://user-images.githubusercontent.com/68801887/226334679-a2a9581a-3330-40de-a972-020b4e296e3b.png)

### 참고사항
manage 페이지들의 파일 구조는 제가 선호하는 방식으로 임의로 나눠놓을 수 있는 대로 세분하게 나눠놓은 상황입니다만,
이는 제 방식을 공유하고자 사용하였으며, 다른 파일구조를 사용하시더라도 괜찮을 것 같습니다.